### PR TITLE
Fix Go Vet Errors

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -24,9 +24,9 @@ jobs:
         run: |
           go mod download
 
-      # - name: Vet
-      #   run: |
-      #     go vet ./...
+      - name: Vet
+        run: |
+          go vet ./...
 
       - name: Test
         run: |

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -124,7 +124,7 @@ func main() {
 	// Create a new consumer, which consumes spans from Kafka and passes the spans to our exporter client, which then
 	// creates the metrics for the service performance monitoring.
 	options := app.Options{
-		kafkaConsumer.Configuration{
+		Configuration: kafkaConsumer.Configuration{
 			// kafkaAuth.AuthenticationConfig{
 			// 	Authentication: kafkaConsumerAuthentication,
 			// 	Kerberos: kafkaAuth.KerberosConfig{
@@ -157,9 +157,9 @@ func main() {
 			ProtocolVersion: kafkaConsumerProtocolVersion,
 			RackID:          kafkaConsumerRackID,
 		},
-		exporterParallelism,
-		kafkaConsumerEncoding,
-		exporterDeadlockInterval,
+		Parallelism:      exporterParallelism,
+		Encoding:         kafkaConsumerEncoding,
+		DeadlockInterval: exporterDeadlockInterval,
 	}
 
 	consumer, err := builder.CreateConsumer(logger, metrics.NullFactory, exp, options)


### PR DESCRIPTION
The app.Options struct literal uses unkeyed fields, which is now fixed so that we can enabled the "go vet ./..." command in the CI/CD pipeline.