### PR TITLE
Adjust Metric Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The **Jaeger Exporter** creates the Prometheus metrics for the [Service Performance Monitoring](https://www.jaegertracing.io/docs/1.37/spm/).
 
-The exporter reuses the Jaeger Ingester logic to consume spans from a particular Kafka topic, but instead of writing them to a storage backend it creates the metrics `calls_total` and `latency` for the Service Performance Monitoring.
+The exporter reuses the Jaeger Ingester logic to consume spans from a particular Kafka topic, but instead of writing them to a storage backend it creates the metrics `calls_total` and `duration_milliseconds_bucket` for the Service Performance Monitoring. To use these metrics the `--prometheus.query.normalize-calls` and `--prometheus.query.normalize-duration` flag must be set for Jaeger.
 
 ![Jaeger UI](./assets/screenshot.png)
 

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -27,9 +27,9 @@ var (
 		Name:      "calls_total",
 	}, []string{"service_name", "operation", "span_kind", "status_code"})
 
-	latencyMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	durationMillisecondsBucketMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "",
-		Name:      "latency",
+		Name:      "duration_milliseconds_bucket",
 		Buckets:   []float64{0.1, 1, 5, 10, 50, 100, 250, 500, 1000, 5000, 10000},
 	}, []string{"service_name", "operation", "span_kind", "status_code"})
 
@@ -98,7 +98,7 @@ func (e *exporter) WriteSpan(ctx context.Context, span *model.Span) error {
 	}
 
 	callsTotalMetric.WithLabelValues(serviceName, operationName, otelSpanKind, statusCode).Inc()
-	latencyMetric.WithLabelValues(serviceName, operationName, otelSpanKind, statusCode).Observe(durationToMillis(span.Duration))
+	durationMillisecondsBucketMetric.WithLabelValues(serviceName, operationName, otelSpanKind, statusCode).Observe(durationToMillis(span.Duration))
 
 	return nil
 }


### PR DESCRIPTION
The `latency` metric was renamed to `duration_milliseconds_bucket` in Jaeger, so that we also have to rename them, so we can use the metrics within Jaeger.

To use the metrics the `--prometheus.query.normalize-calls` and `--prometheus.query.normalize-duration` flags must be set in Jaeger.