### PR TITLE
Add GitHub Container Registry

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -38,6 +38,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Push Docker Image
         id: docker_build
         uses: docker/build-push-action@v6
@@ -46,4 +53,8 @@ jobs:
           context: .
           file: ./cmd/exporter/Dockerfile
           platforms: linux/386,linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-          tags: ricoberger/jaeger-exporter:${{ env.TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}
+            ricoberger/jaeger-exporter:${{ env.TAG }}

--- a/deploy/helm/jaeger-exporter/Chart.yaml
+++ b/deploy/helm/jaeger-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: jaeger-exporter
 description: The Jaeger Exporter creates the Prometheus metrics for the Service Performance Monitoring.
 type: application
-version: 0.5.2
-appVersion: v0.5.2
+version: 0.6.0
+appVersion: v0.6.0

--- a/deploy/helm/jaeger-exporter/values.yaml
+++ b/deploy/helm/jaeger-exporter/values.yaml
@@ -15,9 +15,9 @@ imagePullSecrets: []
 ## Set the image which should be used.
 ##
 image:
-  repository: ricoberger/jaeger-exporter
+  repository: ghcr.io/ricoberger/jaeger-exporter
   pullPolicy: IfNotPresent
-  tag: v0.5.2
+  tag: v0.6.0
 
 ## Specify additional annotations for the created Pods.
 ##

--- a/deploy/kustomize/deployment.yaml
+++ b/deploy/kustomize/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: jaeger-exporter
-          image: "ricoberger/jaeger-exporter:v0.5.2"
+          image: "ghcr.io/ricoberger/jaeger-exporter:v0.6.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Add the Docker image to the GitHub Container Registry as alternative to DockerHub and make GHCR the default in the Helm chart.

This commit also adds the `cache-from` and `cache-to` parameters to the GitHub Action to build the Docker image.